### PR TITLE
Simplify token validation code (a little)

### DIFF
--- a/src/doppler-security/JwtFilter.test.ts
+++ b/src/doppler-security/JwtFilter.test.ts
@@ -7,11 +7,11 @@ describe(JwtFilter.name, () => {
   describe.each([
     {
       tokenName: "token_Expire2033_05_18",
-      jwtFilterRules: { allowAllSignedTokens: true } as const,
+      jwtFilterRules: { allowSimplySignedToken: true } as const,
     },
     {
       tokenName: "token_Superuser_Expire2033_05_18",
-      jwtFilterRules: { allowAllSignedTokens: true } as const,
+      jwtFilterRules: { allowSimplySignedToken: true } as const,
     },
     {
       tokenName: "token_Superuser_Expire2033_05_18",
@@ -26,11 +26,11 @@ describe(JwtFilter.name, () => {
     },
     {
       tokenName: "token_SuperuserFalse_Expire2033_05_18",
-      jwtFilterRules: { allowAllSignedTokens: true } as const,
+      jwtFilterRules: { allowSimplySignedToken: true } as const,
     },
     {
       tokenName: "token_Account_123_test1AtTestDotCom_Expire2033_05_18",
-      jwtFilterRules: { allowAllSignedTokens: true } as const,
+      jwtFilterRules: { allowSimplySignedToken: true } as const,
     },
     {
       tokenName: "token_Account_123_test1AtTestDotCom_Expire2033_05_18",
@@ -76,6 +76,10 @@ describe(JwtFilter.name, () => {
     {
       tokenName: "token_Superuser_Expire2033_05_18",
       jwtFilterRules: { allowUserWithEmail: "otro@test.com" } as const,
+    },
+    {
+      tokenName: "token_Superuser_Expire2033_05_18",
+      jwtFilterRules: {} as const,
     },
     {
       tokenName: "token_SuperuserFalse_Expire2033_05_18",
@@ -150,7 +154,7 @@ describe(JwtFilter.name, () => {
         {
           headers: { authorization: `bearer ${token}` },
         } as unknown as APIGatewayProxyEvent,
-        { allowAllSignedTokens: true },
+        { allowSimplySignedToken: true },
         async () => {
           return {
             statusCode: 200,
@@ -193,7 +197,7 @@ describe(JwtFilter.name, () => {
         const sut = new JwtFilter({ jwtVerifier });
         const result = await sut.apply(
           { headers } as unknown as APIGatewayProxyEvent,
-          { allowAllSignedTokens: true },
+          { allowSimplySignedToken: true },
           async () => {
             return {
               statusCode: 200,

--- a/src/doppler-security/JwtFilter.ts
+++ b/src/doppler-security/JwtFilter.ts
@@ -42,12 +42,9 @@ export class JwtFilter {
 
     if (
       verificationResult.success &&
-      (("allowAllSignedTokens" in rules && rules.allowAllSignedTokens) ||
-        ("allowSuperUser" in rules &&
-          rules.allowSuperUser &&
-          verificationResult.value.isSuperUser) ||
-        ("allowUserWithEmail" in rules &&
-          rules.allowUserWithEmail &&
+      (rules.allowSimplySignedToken ||
+        (rules.allowSuperUser && verificationResult.value.isSuperUser) ||
+        (rules.allowUserWithEmail &&
           verificationResult.value.dopplerUserEmail ===
             rules.allowUserWithEmail))
     ) {

--- a/src/doppler-security/JwtFilterRules.d.ts
+++ b/src/doppler-security/JwtFilterRules.d.ts
@@ -1,14 +1,5 @@
-export type JwtFilterRules =
-  | {
-      allowAllSignedTokens: true;
-    }
-  | {
-      allowSuperUser: true;
-    }
-  | {
-      allowUserWithEmail: string;
-    }
-  | {
-      allowSuperUser: true;
-      allowUserWithEmail: string;
-    };
+export type JwtFilterRules = {
+  allowSimplySignedToken?: true;
+  allowSuperUser?: true;
+  allowUserWithEmail?: string;
+};

--- a/src/doppler-security/JwtVerifier.ts
+++ b/src/doppler-security/JwtVerifier.ts
@@ -14,7 +14,7 @@ export class JwtVerifier {
     try {
       const payload = verify(token, this._publicKey, { complete: false });
 
-      if (typeof payload !== "string" && !payload["exp"]) {
+      if (!payload["exp"]) {
         return { success: false, error: new JsonWebTokenError("exp required") };
       }
 
@@ -25,23 +25,14 @@ export class JwtVerifier {
   }
 
   private mapTokenData(payload: JwtPayload | string): TokenData {
-    return typeof payload === "string"
-      ? {
-          isSuperUser: false,
-          dopplerUserId: null,
-          dopplerUserEmail: null,
-        }
-      : {
-          isSuperUser: "isSU" in payload && payload["isSU"] === true,
-          dopplerUserId:
-            "nameid" in payload && typeof payload["nameid"] === "number"
-              ? payload["nameid"]
-              : null,
-          dopplerUserEmail:
-            "unique_name" in payload &&
-            typeof payload["unique_name"] === "string"
-              ? payload["unique_name"]
-              : null,
-        };
+    return {
+      isSuperUser: payload["isSU"] === true,
+      dopplerUserId:
+        typeof payload["nameid"] === "number" ? payload["nameid"] : null,
+      dopplerUserEmail:
+        typeof payload["unique_name"] === "string" && payload["unique_name"]
+          ? payload["unique_name"]
+          : null,
+    };
   }
 }


### PR DESCRIPTION
These some minor improvements were motivated by [this comment](https://github.com/FromDoppler/aws-node-http-api-project/pull/40#discussion_r1005029725) from @leoslopez.

* Remove redundant type validations (check with string).
* Simplify `JwtFilterRules` and make it more intellisense friendly.
* Rename `allowAllSignedTokens` rule as `allowSimplySignedToken`